### PR TITLE
refactor: migrate all status checks to use REQUEST_STATUS constant

### DIFF
--- a/__tests__/components/billing-info/BillingFormModal.test.tsx
+++ b/__tests__/components/billing-info/BillingFormModal.test.tsx
@@ -47,7 +47,7 @@ describe('BillingFormModal', () => {
     expect(getByPlaceholderText('E.g: Company, Personal, etc.')).toBeTruthy();
     expect(getByPlaceholderText('Full name or company')).toBeTruthy();
     expect(getByPlaceholderText('Complete address')).toBeTruthy();
-    expect(getByPlaceholderText('RFC, NIT, RUT, etc.')).toBeTruthy();
+    expect(getByPlaceholderText('E.g.: B12345678')).toBeTruthy();
   });
 
   it('shows validation errors for required fields', async () => {
@@ -77,7 +77,7 @@ describe('BillingFormModal', () => {
       'Empresa S.A.'
     );
     fireEvent.changeText(getByPlaceholderText('Complete address'), 'Calle 123');
-    fireEvent.changeText(getByPlaceholderText('RFC, NIT, RUT, etc.'), 'RFC123');
+    fireEvent.changeText(getByPlaceholderText('E.g.: B12345678'), 'RFC123');
 
     fireEvent.press(getByText(/save/i));
 
@@ -145,7 +145,7 @@ describe('BillingFormModal', () => {
       'Empresa S.A.'
     );
     fireEvent.changeText(getByPlaceholderText('Complete address'), 'Calle 123');
-    fireEvent.changeText(getByPlaceholderText('RFC, NIT, RUT, etc.'), 'RFC123');
+    fireEvent.changeText(getByPlaceholderText('E.g.: B12345678'), 'RFC123');
 
     fireEvent.press(getByText(/save/i));
 

--- a/__tests__/components/ui/__snapshots__/Input.test.tsx.snap
+++ b/__tests__/components/ui/__snapshots__/Input.test.tsx.snap
@@ -3,22 +3,8 @@
 exports[`Input Accessibility should handle accessibility hint 1`] = `
 <TextInput
   accessibilityHint="Enter your username here"
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
@@ -26,44 +12,16 @@ exports[`Input Accessibility should handle accessibility hint 1`] = `
 exports[`Input Accessibility should handle accessibility label 1`] = `
 <TextInput
   accessibilityLabel="Username input field"
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input Basic rendering should render input correctly 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
@@ -73,22 +31,7 @@ exports[`Input Complex configurations should handle all props together 1`] = `
   accessibilityLabel="Complex input field"
   autoCapitalize="none"
   autoCorrect={false}
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        custom-complex-input
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50 custom-complex-input"
   editable={true}
   keyboardType="email-address"
   multiline={true}
@@ -113,22 +56,8 @@ exports[`Input Complex configurations should handle form-like configuration 1`] 
   autoCapitalize="none"
   autoComplete="email"
   autoCorrect={false}
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   keyboardType="email-address"
   placeholder="Email address"
   placeholderTextColor="#64748b"
@@ -142,22 +71,8 @@ exports[`Input Complex configurations should handle password input configuration
   autoCapitalize="none"
   autoComplete="password"
   autoCorrect={false}
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholder="Password"
   placeholderTextColor="#64748b"
   returnKeyType="done"
@@ -168,22 +83,8 @@ exports[`Input Complex configurations should handle password input configuration
 
 exports[`Input Edge cases should handle null values 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
   style={null}
 />
@@ -191,44 +92,16 @@ exports[`Input Edge cases should handle null values 1`] = `
 
 exports[`Input Edge cases should handle undefined props gracefully 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input Placeholder handling should handle custom placeholder text color through props 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholder="Custom color placeholder"
   placeholderTextColor="#ff0000"
 />
@@ -236,22 +109,8 @@ exports[`Input Placeholder handling should handle custom placeholder text color 
 
 exports[`Input Placeholder handling should handle empty placeholder 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholder=""
   placeholderTextColor="#64748b"
 />
@@ -259,22 +118,8 @@ exports[`Input Placeholder handling should handle empty placeholder 1`] = `
 
 exports[`Input Placeholder handling should handle long placeholder text 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholder="This is a very long placeholder text that might wrap or be truncated"
   placeholderTextColor="#64748b"
 />
@@ -282,22 +127,8 @@ exports[`Input Placeholder handling should handle long placeholder text 1`] = `
 
 exports[`Input Placeholder handling should use default placeholder text color 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholder="Test placeholder"
   placeholderTextColor="#64748b"
 />
@@ -305,22 +136,7 @@ exports[`Input Placeholder handling should use default placeholder text color 1`
 
 exports[`Input State management should handle editable prop 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50 opacity-50"
   editable={false}
   placeholderTextColor="#64748b"
 />
@@ -328,44 +144,16 @@ exports[`Input State management should handle editable prop 1`] = `
 
 exports[`Input Styling and customization should apply custom className 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        custom-input-class
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50 custom-input-class"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input Styling and customization should apply custom style 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
   style={
     {
@@ -379,44 +167,16 @@ exports[`Input Styling and customization should apply custom style 1`] = `
 
 exports[`Input Styling and customization should apply default className 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input Styling and customization should combine className and style 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        text-lg
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50 text-lg"
+  editable={true}
   placeholderTextColor="#64748b"
   style={
     {
@@ -428,44 +188,16 @@ exports[`Input Styling and customization should combine className and style 1`] 
 
 exports[`Input Styling and customization should combine default and custom className 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        border-2 border-red-500
-      "
+  className="h-12 w-full rounded-lg bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50 border-2 border-red-500"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input Styling and customization should handle empty className 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
@@ -473,22 +205,8 @@ exports[`Input Styling and customization should handle empty className 1`] = `
 exports[`Input TextInput props should handle auto-capitalize 1`] = `
 <TextInput
   autoCapitalize="words"
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
@@ -496,22 +214,8 @@ exports[`Input TextInput props should handle auto-capitalize 1`] = `
 exports[`Input TextInput props should handle auto-complete type 1`] = `
 <TextInput
   autoComplete="email"
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
@@ -519,44 +223,16 @@ exports[`Input TextInput props should handle auto-complete type 1`] = `
 exports[`Input TextInput props should handle auto-correct 1`] = `
 <TextInput
   autoCorrect={false}
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
 />
 `;
 
 exports[`Input TextInput props should handle keyboard type 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   keyboardType="email-address"
   placeholderTextColor="#64748b"
 />
@@ -564,22 +240,8 @@ exports[`Input TextInput props should handle keyboard type 1`] = `
 
 exports[`Input TextInput props should handle multiline input 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   multiline={true}
   numberOfLines={4}
   placeholderTextColor="#64748b"
@@ -588,22 +250,8 @@ exports[`Input TextInput props should handle multiline input 1`] = `
 
 exports[`Input TextInput props should handle return key type 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
   returnKeyType="done"
 />
@@ -611,22 +259,8 @@ exports[`Input TextInput props should handle return key type 1`] = `
 
 exports[`Input TextInput props should handle secure text entry 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
   secureTextEntry={true}
 />
@@ -634,22 +268,8 @@ exports[`Input TextInput props should handle secure text entry 1`] = `
 
 exports[`Input TextInput props should handle text content type 1`] = `
 <TextInput
-  className="
-        h-12
-        w-full
-        rounded-lg
-        border
-        border-silver
-        bg-white
-        px-3
-        py-3
-        text-base
-        text-text-black
-        shadow-sm
-        focus:border-cinnabar
-        disabled:opacity-50
-        
-      "
+  className="h-12 w-full rounded-lg border border-silver bg-white px-3 py-3 text-base text-text-black shadow-sm focus:border-cinnabar disabled:opacity-50"
+  editable={true}
   placeholderTextColor="#64748b"
   textContentType="password"
 />

--- a/__tests__/components/ui/__snapshots__/Tooltip.test.tsx.snap
+++ b/__tests__/components/ui/__snapshots__/Tooltip.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Tooltip renders with custom text content 1`] = `
     }
   }
   accessible={true}
-  className="h-4 w-4 items-center justify-center rounded-full bg-black/5"
+  className="items-center justify-center rounded-full bg-black/5"
   collapsable={false}
   focusable={true}
   hitSlop={10}
@@ -42,7 +42,7 @@ exports[`Tooltip renders with custom text content 1`] = `
       [
         {
           "color": "#d75639",
-          "fontSize": 15,
+          "fontSize": 14,
         },
         undefined,
         {

--- a/__tests__/components/verify-phone/VerifyPhoneWizard.test.tsx
+++ b/__tests__/components/verify-phone/VerifyPhoneWizard.test.tsx
@@ -35,7 +35,10 @@ jest.mock('@/hooks/pages/verify-phone/useVerifyPhone', () => ({
 
 jest.mock('@/hooks/useToast', () => ({
   useToast: () => ({
-    toast: mockToast,
+    callToast: ({ variant, description }: any) => {
+      const fn = mockToast[variant as keyof typeof mockToast];
+      if (typeof fn === 'function') fn(description);
+    },
   }),
 }));
 
@@ -479,10 +482,8 @@ describe('VerifyPhoneWizard', () => {
 
       await waitFor(() => {
         expect(mockToast.error).toHaveBeenCalledWith({
-          description: {
-            en: 'Invalid phone number',
-            es: 'Número de teléfono inválido',
-          },
+          en: 'Invalid phone number',
+          es: 'Número de teléfono inválido',
         });
       });
     });

--- a/__tests__/hooks/useToast.test.tsx
+++ b/__tests__/hooks/useToast.test.tsx
@@ -36,6 +36,20 @@ jest.mock('@/providers/ToastProvider', () => ({
   },
 }));
 
+// Mock i18n
+jest.mock('@/i18n', () => ({
+  t: jest.fn((key: string) => {
+    const translations: Record<string, string> = {
+      'screens.editProfile.updateSuccess': 'Profile updated successfully',
+      'screens.addresses.success': 'Address saved successfully',
+      'screens.billingInfo.deleteSuccess': 'Billing information deleted',
+      'screens.verifyPhone.codeSentSuccess': 'Code sent successfully',
+      'screens.editProfile.compressionError': 'Failed to compress image',
+    };
+    return translations[key] || key;
+  }),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -628,6 +642,216 @@ describe('useToast', () => {
 
       expect(Toast.show).toHaveBeenCalledTimes(2);
       expect(Toast.hide).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Translation key support', () => {
+    it('should accept translation key as string and translate it', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: 'screens.editProfile.updateSuccess',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith({
+        type: 'success',
+        position: 'top',
+        text1: 'Success',
+        text2: 'Profile updated successfully',
+        visibilityTime: undefined,
+      });
+    });
+
+    it('should handle translation key for error toast', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.toast.error({
+          description: 'screens.editProfile.compressionError',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text2: 'Failed to compress image',
+        })
+      );
+    });
+
+    it('should handle translation key via shorthand methods', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.toast.success({
+          description: 'screens.addresses.success',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Address saved successfully',
+        })
+      );
+    });
+
+    it('should still accept LangMap objects', () => {
+      const { result } = renderHook(() => useToast('es'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: { es: 'Éxito manual', en: 'Manual success' },
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Éxito manual',
+        })
+      );
+    });
+
+    it('should accept plain error message strings', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.toast.error({
+          description: 'Network error occurred',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Network error occurred',
+        })
+      );
+    });
+
+    it('should handle null description with translation key support', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: null,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: undefined,
+        })
+      );
+    });
+
+    it('should handle undefined description with translation key support', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'info',
+          description: undefined,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: undefined,
+        })
+      );
+    });
+  });
+
+  describe('Real-world patterns with translation keys', () => {
+    it('should handle billing delete success pattern', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.toast.success({
+          description: 'screens.billingInfo.deleteSuccess',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'success',
+          text2: 'Billing information deleted',
+        })
+      );
+    });
+
+    it('should handle phone verification pattern', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.toast.success({
+          description: 'screens.verifyPhone.codeSentSuccess',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Code sent successfully',
+        })
+      );
+    });
+
+    it('should handle API error with LangMap (backend errors)', () => {
+      const { result } = renderHook(() => useToast('es'));
+
+      const apiError = {
+        en: 'Server error occurred',
+        es: 'Ocurrió un error en el servidor',
+      };
+
+      act(() => {
+        result.current.toast.error({ description: apiError });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Ocurrió un error en el servidor',
+        })
+      );
+    });
+
+    it('should handle mixed usage in sequence', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        // Translation key
+        result.current.toast.success({
+          description: 'screens.addresses.success',
+        });
+
+        // LangMap
+        result.current.toast.error({
+          description: { en: 'Network error', es: 'Error de red' },
+        });
+
+        // Plain string
+        result.current.toast.info({
+          description: 'Processing...',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledTimes(3);
+      expect(Toast.show).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ text2: 'Address saved successfully' })
+      );
+      expect(Toast.show).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ text2: 'Network error' })
+      );
+      expect(Toast.show).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ text2: 'Processing...' })
+      );
     });
   });
 });

--- a/__tests__/hooks/useToast.test.tsx
+++ b/__tests__/hooks/useToast.test.tsx
@@ -854,4 +854,179 @@ describe('useToast', () => {
       );
     });
   });
+
+  describe('Type priority and edge cases', () => {
+    it('should prioritize LangMap object over string translation', () => {
+      const { result } = renderHook(() => useToast('es'));
+
+      // LangMap objects should always be treated as LangMap, not as translation keys
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: { es: 'Mensaje directo', en: 'Direct message' },
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Mensaje directo',
+        })
+      );
+    });
+
+    it('should handle object type correctly (LangMap vs string)', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        // LangMap object
+        result.current.callToast({
+          variant: 'success',
+          description: { es: 'Español', en: 'English' },
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'English',
+        })
+      );
+
+      act(() => {
+        // Translation key string
+        result.current.callToast({
+          variant: 'success',
+          description: 'screens.addresses.success',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Address saved successfully',
+        })
+      );
+    });
+
+    it('should handle empty object as LangMap', () => {
+      const { result } = renderHook(() => useToast('es'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: {} as any,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: undefined,
+        })
+      );
+    });
+
+    it('should handle LangMap with only one language key', () => {
+      const { result } = renderHook(() => useToast('es'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: { es: 'Solo español' } as any,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Solo español',
+        })
+      );
+    });
+
+    it('should use correct language from LangMap when locale changes', () => {
+      const { result, rerender } = renderHook(({ lang }) => useToast(lang), {
+        initialProps: { lang: 'es' as 'es' | 'en' },
+      });
+
+      const message = { es: 'Mensaje español', en: 'English message' };
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: message,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Mensaje español',
+        })
+      );
+
+      // Change to English
+      rerender({ lang: 'en' });
+
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: message,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'English message',
+        })
+      );
+    });
+
+    it('should not confuse string with object property access', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      // This should be treated as a translation key, not object property
+      act(() => {
+        result.current.callToast({
+          variant: 'success',
+          description: 'screens.billingInfo.deleteSuccess',
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: 'Billing information deleted',
+        })
+      );
+    });
+
+    it('should handle null explicitly', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'info',
+          description: null,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: undefined,
+        })
+      );
+    });
+
+    it('should handle undefined explicitly', () => {
+      const { result } = renderHook(() => useToast('en'));
+
+      act(() => {
+        result.current.callToast({
+          variant: 'info',
+          description: undefined,
+        });
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text2: undefined,
+        })
+      );
+    });
+  });
 });

--- a/app/(tabs)/account/addresses.tsx
+++ b/app/(tabs)/account/addresses.tsx
@@ -11,7 +11,6 @@ import { AddressFormModal } from '@/components/addresses/AddressFormModal';
 import { EmptyAddressState } from '@/components/addresses/EmptyAddressState';
 import { AddressCard } from '@/components/addresses/AddressCard';
 import { COUNTRIES_MAP_LABEL } from '@/constants/payment';
-import { FontAwesomeIcon } from '@/components/ui/FontAwesomeIcon';
 import type { CountryValue } from '@/types/types';
 
 export default function AddressesScreen() {
@@ -65,32 +64,24 @@ export default function AddressesScreen() {
         edges={['bottom']}
       >
         <View className='flex-1 items-center justify-center p-6'>
-          <FontAwesomeIcon
-            name='exclamation-triangle'
-            size={64}
-            color='#C1463D'
-            variant='light'
-          />
           <CustomText
-            type='h2'
-            className='mb-2 mt-6 text-center text-cinnabar'
+            type='h1'
+            className='mb-2 text-center text-cinnabar'
           >
-            {locale === 'es' ? 'Error al cargar' : 'Error loading'}
+            {t('commonErrors.loadFailedTitle')}
           </CustomText>
           <CustomText
-            type='body'
+            type='h4'
             className='mb-8 text-center'
           >
-            {locale === 'es'
-              ? 'No se pudieron cargar las direcciones'
-              : 'Could not load addresses'}
+            {t('commonErrors.loadFailedMessage')}
           </CustomText>
           <Button
             mode='primary'
             onPress={onRefresh}
             disabled={refreshing}
           >
-            {locale === 'es' ? 'Reintentar' : 'Retry'}
+            {t('commonErrors.retryButton')}
           </Button>
         </View>
       </SafeAreaView>

--- a/app/(tabs)/account/addresses.tsx
+++ b/app/(tabs)/account/addresses.tsx
@@ -5,6 +5,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from '@/hooks/i18n/useTranslation';
 import { useGetAddresses } from '@/hooks/pages/address/useGetAddresses';
 import { CustomText } from '@/components/ui/CustomText';
+import { CustomError } from '@/components/ui/CustomError';
+import { REQUEST_STATUS } from '@/constants';
 import { Button } from '@/components/ui/Button';
 import { Loading } from '@/components/ui/Loading';
 import { AddressFormModal } from '@/components/addresses/AddressFormModal';
@@ -15,7 +17,7 @@ import type { CountryValue } from '@/types/types';
 
 export default function AddressesScreen() {
   const { t, locale } = useTranslation();
-  const { data: addresses, status, refetch } = useGetAddresses();
+  const { data: addresses, status, refetch, errorMessage } = useGetAddresses();
   const [refreshing, setRefreshing] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
 
@@ -52,39 +54,20 @@ export default function AddressesScreen() {
   };
 
   // Loading state - Solo mostrar si NO es un refresh manual
-  if ((status === 'loading' || status === 'idle') && !refreshing) {
+  if (
+    (status === REQUEST_STATUS.loading || status === REQUEST_STATUS.idle) &&
+    !refreshing
+  ) {
     return <Loading locale={locale} />;
   }
 
   // Error state (show error but allow retry)
-  if (status === 'error') {
+  if (status === REQUEST_STATUS.error) {
     return (
-      <SafeAreaView
-        className='flex-1 bg-white'
-        edges={['bottom']}
-      >
-        <View className='flex-1 items-center justify-center p-6'>
-          <CustomText
-            type='h1'
-            className='mb-2 text-center text-cinnabar'
-          >
-            {t('commonErrors.loadFailedTitle')}
-          </CustomText>
-          <CustomText
-            type='h4'
-            className='mb-8 text-center'
-          >
-            {t('commonErrors.loadFailedMessage')}
-          </CustomText>
-          <Button
-            mode='primary'
-            onPress={onRefresh}
-            disabled={refreshing}
-          >
-            {t('commonErrors.retryButton')}
-          </Button>
-        </View>
-      </SafeAreaView>
+      <CustomError
+        customMessage={errorMessage}
+        refreshRoute='/(tabs)/account/addresses'
+      />
     );
   }
 

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -9,6 +9,7 @@ import {
 import { CustomText } from '@/components/ui/CustomText';
 import { Button } from '@/components/ui/Button';
 import { Loading } from '@/components/ui/Loading';
+import { CustomError } from '@/components/ui/CustomError';
 import { EmptyBillingState } from '@/components/billing-info/EmptyBillingState';
 import { BillingCard } from '@/components/billing-info/BillingCard';
 import { BillingFormModal } from '@/components/billing-info/BillingFormModal';
@@ -115,32 +116,10 @@ export default function BillingInfoScreen() {
   // Error state (show error but allow retry)
   if (status === 'error') {
     return (
-      <SafeAreaView
-        className='flex-1 bg-white'
-        edges={['bottom']}
-      >
-        <View className='flex-1 items-center justify-center p-6'>
-          <CustomText
-            type='h1'
-            className='mb-2 text-center text-cinnabar'
-          >
-            {t('commonErrors.loadFailedTitle')}
-          </CustomText>
-          <CustomText
-            type='h4'
-            className='mb-8 text-center'
-          >
-            {t('commonErrors.loadFailedMessage')}
-          </CustomText>
-          <Button
-            mode='primary'
-            onPress={onRefresh}
-            disabled={refreshing}
-          >
-            {t('commonErrors.retryButton')}
-          </Button>
-        </View>
-      </SafeAreaView>
+      <CustomError
+        customMessage={fetchError}
+        refreshRoute='/(tabs)/account/billing-info'
+      />
     );
   }
 

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -16,6 +16,7 @@ import { BillingFormModal } from '@/components/billing-info/BillingFormModal';
 import type { UserBillingInfo } from '@/types/types';
 import type { BillingSchemaType } from '@/utils/schemas/billingSchemas';
 import { useToast } from '@/hooks/useToast';
+import { REQUEST_STATUS } from '@/constants';
 
 export default function BillingInfoScreen() {
   const { t, locale } = useTranslation();
@@ -41,7 +42,7 @@ export default function BillingInfoScreen() {
   // Handle fetch error and delete status
   useEffect(() => {
     // Handle fetch error
-    if (status === 'error' && fetchError) {
+    if (status === REQUEST_STATUS.error && fetchError) {
       callToast({
         variant: 'error',
         description: fetchError,
@@ -49,7 +50,7 @@ export default function BillingInfoScreen() {
     }
 
     // Handle delete success
-    if (deleteStatus === 'success') {
+    if (deleteStatus === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
         description: {
@@ -59,7 +60,7 @@ export default function BillingInfoScreen() {
       });
       setDeletingId(null);
       refetch();
-    } else if (deleteStatus === 'error' && deleteError) {
+    } else if (deleteStatus === REQUEST_STATUS.error && deleteError) {
       callToast({
         variant: 'error',
         description: deleteError,
@@ -107,14 +108,14 @@ export default function BillingInfoScreen() {
   };
 
   // Loading state - Solo mostrar si NO es un refresh manual
-  const loading = status === 'loading' && !refreshing;
+  const loading = status === REQUEST_STATUS.loading && !refreshing;
 
   if (loading) {
     return <Loading locale={locale} />;
   }
 
   // Error state (show error but allow retry)
-  if (status === 'error') {
+  if (status === REQUEST_STATUS.error) {
     return (
       <CustomError
         customMessage={fetchError}
@@ -178,7 +179,7 @@ export default function BillingInfoScreen() {
                 billing={billing}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
-                disabled={refreshing || deleteStatus === 'loading'}
+                disabled={refreshing || deleteStatus === REQUEST_STATUS.loading}
                 isDeleting={deletingId === billing.id}
               />
             ))}

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -14,11 +14,22 @@ import { BillingCard } from '@/components/billing-info/BillingCard';
 import { BillingFormModal } from '@/components/billing-info/BillingFormModal';
 import type { UserBillingInfo } from '@/types/types';
 import type { BillingSchemaType } from '@/utils/schemas/billingSchemas';
+import { useToast } from '@/hooks/useToast';
 
 export default function BillingInfoScreen() {
   const { t, locale } = useTranslation();
-  const { data: billingRecords, status, refetch } = useGetBilling();
-  const { deleteBilling, status: deleteStatus } = useDeleteBilling();
+  const { callToast } = useToast(locale);
+  const {
+    data: billingRecords,
+    status,
+    refetch,
+    errorMessage: fetchError,
+  } = useGetBilling();
+  const {
+    deleteBilling,
+    status: deleteStatus,
+    errorMessage: deleteError,
+  } = useDeleteBilling();
   const [refreshing, setRefreshing] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
@@ -26,19 +37,35 @@ export default function BillingInfoScreen() {
     (BillingSchemaType & { id?: string }) | undefined
   >(undefined);
 
-  // Handle delete success - refetch is now stable, no loop
+  // Handle fetch error and delete status
   useEffect(() => {
+    // Handle fetch error
+    if (status === 'error' && fetchError) {
+      callToast({
+        variant: 'error',
+        description: fetchError,
+      });
+    }
+
+    // Handle delete success
     if (deleteStatus === 'success') {
-      console.log('✅ Billing deleted successfully');
-      // TODO: Show success toast
+      callToast({
+        variant: 'success',
+        description: {
+          en: t('screens.billingInfo.deleteSuccess'),
+          es: t('screens.billingInfo.deleteSuccess'),
+        },
+      });
       setDeletingId(null);
-      refetch(); // Refresh list after delete
-    } else if (deleteStatus === 'error') {
-      console.error('❌ Delete billing failed');
-      // TODO: Show error toast
+      refetch();
+    } else if (deleteStatus === 'error' && deleteError) {
+      callToast({
+        variant: 'error',
+        description: deleteError,
+      });
       setDeletingId(null);
     }
-  }, [deleteStatus, refetch]);
+  }, [status, fetchError, deleteStatus, deleteError, refetch, callToast, t]);
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);
@@ -51,8 +78,6 @@ export default function BillingInfoScreen() {
   };
 
   const handleEdit = (billing: UserBillingInfo) => {
-    console.log('✏️ Editar billing:', billing.id);
-
     // Convert UserBillingInfo to BillingSchemaType format
     setBillingToEdit({
       id: billing.id,
@@ -65,7 +90,6 @@ export default function BillingInfoScreen() {
   };
 
   const handleDelete = async (billing: UserBillingInfo) => {
-    // TODO: Show confirmation modal
     setDeletingId(billing.id);
     await deleteBilling(billing.id);
   };

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -54,8 +54,8 @@ export default function BillingInfoScreen() {
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.billingInfo.deleteSuccess'),
-          es: t('screens.billingInfo.deleteSuccess'),
+          en: 'Billing information deleted successfully',
+          es: 'Información de facturación eliminada exitosamente',
         },
       });
       setDeletingId(null);

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -53,10 +53,7 @@ export default function BillingInfoScreen() {
     if (deleteStatus === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
-        description: {
-          en: 'Billing information deleted successfully',
-          es: 'Información de facturación eliminada exitosamente',
-        },
+        description: 'screens.billingInfo.deleteSuccess',
       });
       setDeletingId(null);
       refetch();
@@ -67,7 +64,7 @@ export default function BillingInfoScreen() {
       });
       setDeletingId(null);
     }
-  }, [status, fetchError, deleteStatus, deleteError, refetch, callToast, t]);
+  }, [status, fetchError, deleteStatus, deleteError, refetch, callToast]);
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);

--- a/app/(tabs)/account/billing-info.tsx
+++ b/app/(tabs)/account/billing-info.tsx
@@ -112,6 +112,38 @@ export default function BillingInfoScreen() {
     return <Loading locale={locale} />;
   }
 
+  // Error state (show error but allow retry)
+  if (status === 'error') {
+    return (
+      <SafeAreaView
+        className='flex-1 bg-white'
+        edges={['bottom']}
+      >
+        <View className='flex-1 items-center justify-center p-6'>
+          <CustomText
+            type='h1'
+            className='mb-2 text-center text-cinnabar'
+          >
+            {t('commonErrors.loadFailedTitle')}
+          </CustomText>
+          <CustomText
+            type='h4'
+            className='mb-8 text-center'
+          >
+            {t('commonErrors.loadFailedMessage')}
+          </CustomText>
+          <Button
+            mode='primary'
+            onPress={onRefresh}
+            disabled={refreshing}
+          >
+            {t('commonErrors.retryButton')}
+          </Button>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   // Empty state
   if (billingRecords.length === 0) {
     return (

--- a/app/(tabs)/account/edit-profile.tsx
+++ b/app/(tabs)/account/edit-profile.tsx
@@ -111,7 +111,7 @@ export default function EditProfileScreen() {
   useEffect(() => {
     if (!isSubmittingRef.current) return;
 
-    if (updateStatus === 'success') {
+    if (updateStatus === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
         description: {
@@ -121,7 +121,7 @@ export default function EditProfileScreen() {
       });
       router.back();
       isSubmittingRef.current = false;
-    } else if (updateStatus === 'error' && updateError) {
+    } else if (updateStatus === REQUEST_STATUS.error && updateError) {
       callToast({
         variant: 'error',
         description: updateError,

--- a/app/(tabs)/account/edit-profile.tsx
+++ b/app/(tabs)/account/edit-profile.tsx
@@ -115,8 +115,8 @@ export default function EditProfileScreen() {
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.editProfile.updateSuccess'),
-          es: t('screens.editProfile.updateSuccess'),
+          en: 'Profile updated successfully',
+          es: 'Perfil actualizado exitosamente',
         },
       });
       router.back();

--- a/app/(tabs)/account/edit-profile.tsx
+++ b/app/(tabs)/account/edit-profile.tsx
@@ -18,10 +18,12 @@ import { Loading } from '@/components/ui/Loading';
 import { APP_USER_ROLES } from '@/constants/user';
 import type * as z from 'zod';
 import { REQUEST_STATUS } from '@/constants';
+import { useToast } from '@/hooks/useToast';
 
 export default function EditProfileScreen() {
   const { t, locale } = useTranslation();
   const { auth } = useAuth();
+  const { callToast } = useToast(locale);
   const isSubmittingRef = useRef(false);
 
   // Usar los nuevos hooks
@@ -105,28 +107,39 @@ export default function EditProfileScreen() {
   // Handle fetch errors
   useEffect(() => {
     if (fetchStatus === 'error') {
-      console.error('ERROR_LOAD_USER_DATA', fetchError);
-      // TODO: Show toast with fetchError[locale]
+      callToast({
+        variant: 'error',
+        description: fetchError || {
+          en: t('screens.editProfile.loadError'),
+          es: t('screens.editProfile.loadError'),
+        },
+      });
       router.back();
     }
-  }, [fetchStatus, fetchError, locale]);
+  }, [fetchStatus, fetchError, locale, callToast, t]);
 
   // Handle update result (success or error)
   useEffect(() => {
     if (!isSubmittingRef.current) return;
 
     if (updateStatus === 'success') {
-      console.log('SUCCESS_UPDATE_PROFILE');
-      // TODO: Show success toast
+      callToast({
+        variant: 'success',
+        description: {
+          en: t('screens.editProfile.updateSuccess'),
+          es: t('screens.editProfile.updateSuccess'),
+        },
+      });
       router.back();
       isSubmittingRef.current = false;
     } else if (updateStatus === 'error' && updateError) {
-      console.error('ERROR_UPDATE_PROFILE', updateError);
-      // TODO: Show error toast with updateError[locale]
-      router.back();
+      callToast({
+        variant: 'error',
+        description: updateError,
+      });
       isSubmittingRef.current = false;
     }
-  }, [updateStatus, updateError, locale]);
+  }, [updateStatus, updateError, locale, callToast, t]);
 
   const onSubmit = async (
     data: z.infer<typeof UserEditSchema> | z.infer<typeof AuctioneerEditSchema>

--- a/app/(tabs)/account/edit-profile.tsx
+++ b/app/(tabs)/account/edit-profile.tsx
@@ -114,10 +114,7 @@ export default function EditProfileScreen() {
     if (updateStatus === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
-        description: {
-          en: 'Profile updated successfully',
-          es: 'Perfil actualizado exitosamente',
-        },
+        description: 'screens.editProfile.updateSuccess',
       });
       router.back();
       isSubmittingRef.current = false;
@@ -128,7 +125,7 @@ export default function EditProfileScreen() {
       });
       isSubmittingRef.current = false;
     }
-  }, [updateStatus, updateError, locale, callToast, t]);
+  }, [updateStatus, updateError, locale, callToast]);
 
   const onSubmit = async (
     data: z.infer<typeof UserEditSchema> | z.infer<typeof AuctioneerEditSchema>

--- a/app/(tabs)/account/edit-profile.tsx
+++ b/app/(tabs)/account/edit-profile.tsx
@@ -15,6 +15,7 @@ import { getErrorMessage } from '@/utils/form-errors';
 import { useGetCurrentUser } from '@/hooks/pages/user/useGetCurrentUser';
 import { useUpdateProfile } from '@/hooks/pages/user/useUpdateProfile';
 import { Loading } from '@/components/ui/Loading';
+import { CustomError } from '@/components/ui/CustomError';
 import { APP_USER_ROLES } from '@/constants/user';
 import type * as z from 'zod';
 import { REQUEST_STATUS } from '@/constants';
@@ -104,19 +105,7 @@ export default function EditProfileScreen() {
     }
   }, [currentUserData, userRole, reset]);
 
-  // Handle fetch errors
-  useEffect(() => {
-    if (fetchStatus === 'error') {
-      callToast({
-        variant: 'error',
-        description: fetchError || {
-          en: t('screens.editProfile.loadError'),
-          es: t('screens.editProfile.loadError'),
-        },
-      });
-      router.back();
-    }
-  }, [fetchStatus, fetchError, locale, callToast, t]);
+  // No useEffect for fetch errors - we handle it in the render
 
   // Handle update result (success or error)
   useEffect(() => {
@@ -161,6 +150,16 @@ export default function EditProfileScreen() {
   // Show loading while fetching user data
   if (fetchStatus === REQUEST_STATUS.loading) {
     return <Loading locale={locale} />;
+  }
+
+  // Show error if fetch failed or if we don't have user data
+  if (fetchStatus === REQUEST_STATUS.error || !currentUserData) {
+    return (
+      <CustomError
+        customMessage={fetchError}
+        refreshRoute='/(tabs)/account/edit-profile'
+      />
+    );
   }
 
   // Compute loading state for form controls

--- a/app/(tabs)/account/payments-history.tsx
+++ b/app/(tabs)/account/payments-history.tsx
@@ -2,7 +2,6 @@ import { View, ScrollView, RefreshControl } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from '@/hooks/i18n/useTranslation';
 import { CustomText } from '@/components/ui/CustomText';
-import { Button } from '@/components/ui/Button';
 import { Loading } from '@/components/ui/Loading';
 import { PaymentCard } from '@/components/payment-history/PaymentCard';
 import { EmptyPaymentHistory } from '@/components/payment-history/EmptyPaymentHistory';
@@ -35,24 +34,17 @@ export default function PaymentsHistoryScreen() {
       >
         <View className='flex-1 items-center justify-center p-6'>
           <CustomText
-            type='h1'
-            className='mb-2 text-center text-cinnabar'
+            type='h3'
+            className='mb-4 text-center text-red-500'
           >
-            {t('commonErrors.loadFailedTitle')}
+            {t('commonErrors.generic')}
           </CustomText>
           <CustomText
-            type='h4'
-            className='mb-8 text-center'
+            type='body'
+            className='text-gray-600 text-center'
           >
-            {t('commonErrors.loadFailedMessage')}
+            {t('commonErrors.defaultMessage')}
           </CustomText>
-          <Button
-            mode='primary'
-            onPress={onRefresh}
-            disabled={refreshing}
-          >
-            {t('commonErrors.retryButton')}
-          </Button>
         </View>
       </SafeAreaView>
     );

--- a/app/(tabs)/account/payments-history.tsx
+++ b/app/(tabs)/account/payments-history.tsx
@@ -7,10 +7,17 @@ import { PaymentCard } from '@/components/payment-history/PaymentCard';
 import { EmptyPaymentHistory } from '@/components/payment-history/EmptyPaymentHistory';
 import { useGetPaymentHistory } from '@/hooks/pages/payment/useGetPaymentHistory';
 import { useState, useCallback } from 'react';
+import { REQUEST_STATUS } from '@/constants';
+import { CustomError } from '@/components/ui/CustomError';
 
 export default function PaymentsHistoryScreen() {
   const { t, locale } = useTranslation();
-  const { data: payments, status, refetch } = useGetPaymentHistory();
+  const {
+    data: payments,
+    status,
+    refetch,
+    errorMessage,
+  } = useGetPaymentHistory();
   const [refreshing, setRefreshing] = useState(false);
 
   const onRefresh = useCallback(async () => {
@@ -19,34 +26,19 @@ export default function PaymentsHistoryScreen() {
     setRefreshing(false);
   }, [refetch]);
 
-  // Loading state - Solo mostrar si NO es un refresh manual
-  // Si refreshing=true, el usuario ve el loader nativo del gesto
-  if ((status === 'loading' || status === 'idle') && !refreshing) {
+  if (
+    (status === REQUEST_STATUS.loading || status === REQUEST_STATUS.idle) &&
+    !refreshing
+  ) {
     return <Loading locale={locale} />;
   }
 
-  // Error state (show error but allow retry)
-  if (status === 'error') {
+  if (status === REQUEST_STATUS.error) {
     return (
-      <SafeAreaView
-        className='flex-1 bg-white'
-        edges={['bottom']}
-      >
-        <View className='flex-1 items-center justify-center p-6'>
-          <CustomText
-            type='h3'
-            className='mb-4 text-center text-red-500'
-          >
-            {t('commonErrors.generic')}
-          </CustomText>
-          <CustomText
-            type='body'
-            className='text-gray-600 text-center'
-          >
-            {t('commonErrors.defaultMessage')}
-          </CustomText>
-        </View>
-      </SafeAreaView>
+      <CustomError
+        customMessage={errorMessage}
+        refreshRoute='/(tabs)/account/payments-history'
+      />
     );
   }
 

--- a/app/(tabs)/account/payments-history.tsx
+++ b/app/(tabs)/account/payments-history.tsx
@@ -2,6 +2,7 @@ import { View, ScrollView, RefreshControl } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTranslation } from '@/hooks/i18n/useTranslation';
 import { CustomText } from '@/components/ui/CustomText';
+import { Button } from '@/components/ui/Button';
 import { Loading } from '@/components/ui/Loading';
 import { PaymentCard } from '@/components/payment-history/PaymentCard';
 import { EmptyPaymentHistory } from '@/components/payment-history/EmptyPaymentHistory';
@@ -34,17 +35,24 @@ export default function PaymentsHistoryScreen() {
       >
         <View className='flex-1 items-center justify-center p-6'>
           <CustomText
-            type='h3'
-            className='mb-4 text-center text-red-500'
+            type='h1'
+            className='mb-2 text-center text-cinnabar'
           >
-            {t('commonErrors.generic')}
+            {t('commonErrors.loadFailedTitle')}
           </CustomText>
           <CustomText
-            type='body'
-            className='text-gray-600 text-center'
+            type='h4'
+            className='mb-8 text-center'
           >
-            {t('commonErrors.defaultMessage')}
+            {t('commonErrors.loadFailedMessage')}
           </CustomText>
+          <Button
+            mode='primary'
+            onPress={onRefresh}
+            disabled={refreshing}
+          >
+            {t('commonErrors.retryButton')}
+          </Button>
         </View>
       </SafeAreaView>
     );

--- a/app/(tabs)/account/verify-phone.tsx
+++ b/app/(tabs)/account/verify-phone.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '@/hooks/i18n/useTranslation';
 import { useGetCurrentUser } from '@/hooks/pages/user/useGetCurrentUser';
 import { VerifyPhoneWizard } from '@/components/verify-phone/VerifyPhoneWizard';
 import { Loading } from '@/components/ui/Loading';
+import { REQUEST_STATUS } from '@/constants';
 
 export default function VerifyPhoneScreen() {
   const { locale } = useTranslation();
@@ -14,18 +15,21 @@ export default function VerifyPhoneScreen() {
 
   // Redirect to account if no user (like web version)
   useEffect(() => {
-    if (status === 'error' || (!currentUser && status === 'success')) {
+    if (
+      status === REQUEST_STATUS.error ||
+      (!currentUser && status === REQUEST_STATUS.success)
+    ) {
       router.replace('/(tabs)/account');
     }
   }, [status, currentUser, router]);
 
   // Loading state
-  if (status === 'loading' || status === 'idle') {
+  if (status === REQUEST_STATUS.loading || status === REQUEST_STATUS.idle) {
     return <Loading locale={locale} />;
   }
 
   // If redirecting, show loading while navigating
-  if (status === 'error' || !currentUser) {
+  if (status === REQUEST_STATUS.error || !currentUser) {
     return <Loading locale={locale} />;
   }
 

--- a/app/(tabs)/auctions/calendar.tsx
+++ b/app/(tabs)/auctions/calendar.tsx
@@ -7,6 +7,7 @@ import { CustomText } from '@/components/ui/CustomText';
 import { AuctionCalendarCard } from '@/components/ui/AuctionCalendarCard';
 import { Button } from '@/components/ui/Button';
 import { Loading } from '@/components/ui/Loading';
+import { REQUEST_STATUS } from '@/constants';
 
 export default function CalendarScreen() {
   const { auctions, status, refetch } = useAuctionsCalendar();
@@ -21,11 +22,11 @@ export default function CalendarScreen() {
   const nextMonth = monthsArray[1];
   const hasAuctionsNextMonth = auctions?.next_month?.length > 0 || false;
 
-  if (status === 'loading') {
+  if (status === REQUEST_STATUS.loading) {
     return <Loading locale={locale} />;
   }
 
-  if (status === 'error') {
+  if (status === REQUEST_STATUS.error) {
     return (
       <View className='flex-1 items-center justify-center p-4'>
         <CustomText

--- a/app/(tabs)/auth/login.tsx
+++ b/app/(tabs)/auth/login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, View, AppState, ScrollView } from 'react-native';
+import { View, AppState, ScrollView } from 'react-native';
 import { supabase } from '@/utils/supabase/supabase-store';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button } from '@/components/ui/Button';
@@ -10,6 +10,7 @@ import { BackgroundImage } from '@/components/ui/BackgroundImage';
 import { router } from 'expo-router';
 import { CustomText } from '@/components/ui/CustomText';
 import { CustomLink } from '@/components/ui/CustomLink';
+import { useToast } from '@/hooks/useToast';
 
 // Tells Supabase Auth to continuously refresh the session automatically if
 // the app is in the foreground. When this is added, you will continue to receive
@@ -28,7 +29,8 @@ export default function Auth() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
+  const { callToast } = useToast(locale);
 
   async function signInWithEmail() {
     setLoading(true);
@@ -38,7 +40,13 @@ export default function Auth() {
     });
 
     if (error) {
-      Alert.alert(error.message);
+      callToast({
+        variant: 'error',
+        description: {
+          en: error.message,
+          es: error.message,
+        },
+      });
     } else {
       // Login exitoso - redirigir al home y reemplazar la pantalla de login
       router.replace('/(tabs)/home');

--- a/app/(tabs)/auth/login.tsx
+++ b/app/(tabs)/auth/login.tsx
@@ -42,10 +42,7 @@ export default function Auth() {
     if (error) {
       callToast({
         variant: 'error',
-        description: {
-          en: error.message,
-          es: error.message,
-        },
+        description: error.message,
       });
     } else {
       // Login exitoso - redirigir al home y reemplazar la pantalla de login

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "expo-dev-client": "~5.2.4",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
+        "expo-image-manipulator": "~13.1.7",
         "expo-image-picker": "~16.1.4",
         "expo-linking": "~7.1.7",
         "expo-localization": "~16.1.6",
@@ -2534,9 +2535,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7159,9 +7160,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -9020,6 +9021,18 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz",
+      "integrity": "sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-image-picker": {
       "version": "16.1.4",
       "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
@@ -9777,9 +9790,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -12608,9 +12621,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "expo-dev-client": "~5.2.4",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
+    "expo-image-manipulator": "~13.1.7",
     "expo-image-picker": "~16.1.4",
     "expo-linking": "~7.1.7",
     "expo-localization": "~16.1.6",

--- a/src/components/addresses/AddressFormModal.tsx
+++ b/src/components/addresses/AddressFormModal.tsx
@@ -62,8 +62,8 @@ export function AddressFormModal({
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.addresses.success'),
-          es: t('screens.addresses.success'),
+          en: 'Address saved successfully',
+          es: 'Dirección guardada correctamente',
         },
       });
       reset();

--- a/src/components/addresses/AddressFormModal.tsx
+++ b/src/components/addresses/AddressFormModal.tsx
@@ -62,8 +62,8 @@ export function AddressFormModal({
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.addresses.form.createSuccess'),
-          es: t('screens.addresses.form.createSuccess'),
+          en: t('screens.addresses.success'),
+          es: t('screens.addresses.success'),
         },
       });
       reset();

--- a/src/components/addresses/AddressFormModal.tsx
+++ b/src/components/addresses/AddressFormModal.tsx
@@ -61,10 +61,7 @@ export function AddressFormModal({
     if (status === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
-        description: {
-          en: 'Address saved successfully',
-          es: 'Dirección guardada correctamente',
-        },
+        description: 'screens.addresses.success',
       });
       reset();
       onSuccess();
@@ -77,7 +74,7 @@ export function AddressFormModal({
       });
       isSubmittingRef.current = false;
     }
-  }, [status, errorMessage, locale, reset, onSuccess, onClose, callToast, t]);
+  }, [status, errorMessage, locale, reset, onSuccess, onClose, callToast]);
 
   const onSubmit = async (data: AddressSchemaType) => {
     isSubmittingRef.current = true;

--- a/src/components/addresses/AddressFormModal.tsx
+++ b/src/components/addresses/AddressFormModal.tsx
@@ -13,6 +13,7 @@ import { useCreateAddress } from '@/hooks/pages/address/useCreateAddress';
 import { getErrorMessage } from '@/utils/form-errors';
 import { COUNTRIES_MAP } from '@/constants/payment';
 import type { CountryObject } from '@/types/types';
+import { useToast } from '@/hooks/useToast';
 
 interface AddressFormModalProps {
   visible: boolean;
@@ -26,6 +27,7 @@ export function AddressFormModal({
   onSuccess,
 }: AddressFormModalProps) {
   const { t, locale } = useTranslation();
+  const { callToast } = useToast(locale);
   const { createAddress, status, errorMessage } = useCreateAddress();
   const isSubmittingRef = useRef(false);
 
@@ -56,18 +58,25 @@ export function AddressFormModal({
     if (!isSubmittingRef.current) return;
 
     if (status === 'success') {
-      console.log('SUCCESS_CREATE_ADDRESS');
-      // TODO: Mostrar toast de éxito
+      callToast({
+        variant: 'success',
+        description: {
+          en: t('screens.addresses.form.createSuccess'),
+          es: t('screens.addresses.form.createSuccess'),
+        },
+      });
       reset();
       onSuccess();
       onClose();
       isSubmittingRef.current = false;
     } else if (status === 'error' && errorMessage) {
-      console.error('ERROR_CREATE_ADDRESS', errorMessage);
-      // TODO: Mostrar toast con errorMessage[locale]
+      callToast({
+        variant: 'error',
+        description: errorMessage,
+      });
       isSubmittingRef.current = false;
     }
-  }, [status, errorMessage, locale, reset, onSuccess, onClose]);
+  }, [status, errorMessage, locale, reset, onSuccess, onClose, callToast, t]);
 
   const onSubmit = async (data: AddressSchemaType) => {
     isSubmittingRef.current = true;

--- a/src/components/addresses/AddressFormModal.tsx
+++ b/src/components/addresses/AddressFormModal.tsx
@@ -14,6 +14,7 @@ import { getErrorMessage } from '@/utils/form-errors';
 import { COUNTRIES_MAP } from '@/constants/payment';
 import type { CountryObject } from '@/types/types';
 import { useToast } from '@/hooks/useToast';
+import { REQUEST_STATUS } from '@/constants';
 
 interface AddressFormModalProps {
   visible: boolean;
@@ -51,13 +52,13 @@ export function AddressFormModal({
     },
   });
 
-  const isSubmitting = status === 'loading';
+  const isSubmitting = status === REQUEST_STATUS.loading;
 
   // React to status changes only after a submit attempt
   useEffect(() => {
     if (!isSubmittingRef.current) return;
 
-    if (status === 'success') {
+    if (status === REQUEST_STATUS.success) {
       callToast({
         variant: 'success',
         description: {
@@ -69,7 +70,7 @@ export function AddressFormModal({
       onSuccess();
       onClose();
       isSubmittingRef.current = false;
-    } else if (status === 'error' && errorMessage) {
+    } else if (status === REQUEST_STATUS.error && errorMessage) {
       callToast({
         variant: 'error',
         description: errorMessage,

--- a/src/components/billing-info/BillingFormModal.tsx
+++ b/src/components/billing-info/BillingFormModal.tsx
@@ -63,18 +63,15 @@ export function BillingFormModal({
       console.log(`✅ ${isEditMode ? 'UPDATED' : 'CREATED'} BILLING`);
       callToast({
         variant: 'success',
-        description: {
-          en: t(
-            isEditMode
-              ? 'screens.billingInfo.updateSuccess'
-              : 'screens.billingInfo.createSuccess'
-          ),
-          es: t(
-            isEditMode
-              ? 'screens.billingInfo.updateSuccess'
-              : 'screens.billingInfo.createSuccess'
-          ),
-        },
+        description: isEditMode
+          ? {
+              en: 'Billing information updated successfully',
+              es: 'Información de facturación actualizada exitosamente',
+            }
+          : {
+              en: 'Billing information created successfully',
+              es: 'Información de facturación creada exitosamente',
+            },
       });
       isSubmittingRef.current = false;
       reset();

--- a/src/components/billing-info/BillingFormModal.tsx
+++ b/src/components/billing-info/BillingFormModal.tsx
@@ -64,14 +64,8 @@ export function BillingFormModal({
       callToast({
         variant: 'success',
         description: isEditMode
-          ? {
-              en: 'Billing information updated successfully',
-              es: 'Información de facturación actualizada exitosamente',
-            }
-          : {
-              en: 'Billing information created successfully',
-              es: 'Información de facturación creada exitosamente',
-            },
+          ? 'screens.billingInfo.updateSuccess'
+          : 'screens.billingInfo.createSuccess',
       });
       isSubmittingRef.current = false;
       reset();
@@ -84,7 +78,7 @@ export function BillingFormModal({
       // Error handling is done in the parent screen (billing-info.tsx)
       isSubmittingRef.current = false;
     }
-  }, [currentStatus, visible, isEditMode, reset, onSuccess, callToast, t]);
+  }, [currentStatus, visible, isEditMode, reset, onSuccess, callToast]);
 
   // Populate form when billingToEdit changes
   useEffect(() => {

--- a/src/components/billing-info/BillingFormModal.tsx
+++ b/src/components/billing-info/BillingFormModal.tsx
@@ -15,6 +15,7 @@ import {
   type BillingSchemaType,
 } from '@/utils/schemas/billingSchemas';
 import { useToast } from '@/hooks/useToast';
+import { REQUEST_STATUS } from '@/constants';
 
 interface BillingFormModalProps {
   visible: boolean;
@@ -37,7 +38,7 @@ export function BillingFormModal({
 
   const isEditMode = billingToEdit?.id !== undefined;
   const currentStatus = isEditMode ? updateStatus : createStatus;
-  const isSubmitting = currentStatus === 'loading';
+  const isSubmitting = currentStatus === REQUEST_STATUS.loading;
 
   const {
     control,
@@ -58,7 +59,7 @@ export function BillingFormModal({
   useEffect(() => {
     if (!visible) return;
 
-    if (currentStatus === 'success' && isSubmittingRef.current) {
+    if (currentStatus === REQUEST_STATUS.success && isSubmittingRef.current) {
       console.log(`✅ ${isEditMode ? 'UPDATED' : 'CREATED'} BILLING`);
       callToast({
         variant: 'success',
@@ -78,7 +79,10 @@ export function BillingFormModal({
       isSubmittingRef.current = false;
       reset();
       onSuccess();
-    } else if (currentStatus === 'error' && isSubmittingRef.current) {
+    } else if (
+      currentStatus === REQUEST_STATUS.error &&
+      isSubmittingRef.current
+    ) {
       console.log('❌ ERROR_SAVE_BILLING');
       // Error handling is done in the parent screen (billing-info.tsx)
       isSubmittingRef.current = false;

--- a/src/components/billing-info/BillingFormModal.tsx
+++ b/src/components/billing-info/BillingFormModal.tsx
@@ -14,6 +14,7 @@ import {
   BillingSchema,
   type BillingSchemaType,
 } from '@/utils/schemas/billingSchemas';
+import { useToast } from '@/hooks/useToast';
 
 interface BillingFormModalProps {
   visible: boolean;
@@ -29,6 +30,7 @@ export function BillingFormModal({
   billingToEdit,
 }: BillingFormModalProps) {
   const { t, locale } = useTranslation();
+  const { callToast } = useToast(locale);
   const { createBilling, status: createStatus } = useCreateBilling();
   const { updateBilling, status: updateStatus } = useUpdateBilling();
   const isSubmittingRef = useRef(false);
@@ -58,16 +60,30 @@ export function BillingFormModal({
 
     if (currentStatus === 'success' && isSubmittingRef.current) {
       console.log(`✅ ${isEditMode ? 'UPDATED' : 'CREATED'} BILLING`);
-      // TODO: Show success toast
+      callToast({
+        variant: 'success',
+        description: {
+          en: t(
+            isEditMode
+              ? 'screens.billingInfo.updateSuccess'
+              : 'screens.billingInfo.createSuccess'
+          ),
+          es: t(
+            isEditMode
+              ? 'screens.billingInfo.updateSuccess'
+              : 'screens.billingInfo.createSuccess'
+          ),
+        },
+      });
       isSubmittingRef.current = false;
       reset();
       onSuccess();
     } else if (currentStatus === 'error' && isSubmittingRef.current) {
-      console.error('❌ ERROR_SAVE_BILLING');
-      // TODO: Show error toast
+      console.log('❌ ERROR_SAVE_BILLING');
+      // Error handling is done in the parent screen (billing-info.tsx)
       isSubmittingRef.current = false;
     }
-  }, [currentStatus, visible, isEditMode, reset, onSuccess]);
+  }, [currentStatus, visible, isEditMode, reset, onSuccess, callToast, t]);
 
   // Populate form when billingToEdit changes
   useEffect(() => {
@@ -110,8 +126,8 @@ export function BillingFormModal({
       }
     } catch (error) {
       console.error('❌ ERROR_SAVE_BILLING_CATCH:', error);
+      // Error handling is done in the parent screen (billing-info.tsx)
       isSubmittingRef.current = false;
-      // TODO: Mostrar toast con error
     }
   };
 

--- a/src/components/payment-history/EmptyPaymentHistory.tsx
+++ b/src/components/payment-history/EmptyPaymentHistory.tsx
@@ -29,14 +29,8 @@ export function EmptyPaymentHistory({
         }
       >
         <CustomText
-          type='h1'
-          className='my-4 text-center text-cinnabar'
-        >
-          {t('screens.paymentsHistory.title')}
-        </CustomText>
-        <CustomText
-          type='h3'
-          className='my-8 text-center'
+          type='h2'
+          className='text-center text-cinnabar'
         >
           {t('screens.paymentsHistory.noPaymentsYet')}
         </CustomText>

--- a/src/components/ui/CustomError.tsx
+++ b/src/components/ui/CustomError.tsx
@@ -1,0 +1,71 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { View } from '../Themed';
+import { CustomText } from './CustomText';
+import { useTranslation } from '@/hooks/i18n/useTranslation';
+import { Button } from './Button';
+import { CustomLink } from './CustomLink';
+import { type Href, useRouter } from 'expo-router';
+import { LangMap } from '@/types/types';
+
+interface CustomErrorProps {
+  refreshRoute: Href;
+  customMessage?: LangMap | null;
+}
+
+export const CustomError = ({
+  refreshRoute,
+  customMessage,
+}: CustomErrorProps) => {
+  const { t, locale } = useTranslation();
+  const router = useRouter();
+
+  const message = customMessage?.[locale];
+
+  const handleRefresh = () => {
+    router.replace(refreshRoute);
+  };
+
+  return (
+    <SafeAreaView
+      className='h-full w-full bg-white'
+      edges={['bottom']}
+    >
+      <View className='flex h-full w-full flex-col items-center justify-center text-center'>
+        <CustomText
+          type='h2'
+          className='mb-4 text-center text-cinnabar'
+        >
+          {t('commonErrors.generic')}
+        </CustomText>
+        {message && (
+          <CustomText
+            type='h4'
+            className='mb-2 text-center'
+          >
+            {message}
+          </CustomText>
+        )}
+        <CustomText
+          type='body'
+          className='text-center text-base'
+        >
+          {t('commonErrors.defaultMessage')}
+        </CustomText>
+        <View className='mt-4 flex flex-row gap-4'>
+          <Button
+            mode='primary'
+            onPress={handleRefresh}
+          >
+            Refresh page
+          </Button>
+          <CustomLink
+            href='/home'
+            mode='secondary'
+          >
+            Go to home page
+          </CustomLink>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};

--- a/src/components/ui/FollowButton.tsx
+++ b/src/components/ui/FollowButton.tsx
@@ -4,6 +4,7 @@ import { Button, ButtonMode, ButtonSize } from './Button';
 import { useSecureApi } from '@/hooks/api/useSecureApi';
 import { useToast } from '@/hooks/useToast';
 import { sentryErrorReport } from '@/lib/error/sentry-error-report';
+import { REQUEST_STATUS } from '@/constants';
 
 interface FollowButtonProps {
   mode: ButtonMode;
@@ -50,10 +51,10 @@ export function FollowButton({
   const { securePost } = useSecureApi();
   const { callToast } = useToast(lang);
 
-  const isLoading = status === 'loading';
+  const isLoading = status === REQUEST_STATUS.loading;
 
   const handleClick = async () => {
-    setStatus('loading');
+    setStatus(REQUEST_STATUS.loading as RequestStatus);
     const endpoint = isFollowing ? unfollowEndpoint : followEndpoint;
 
     try {
@@ -61,18 +62,18 @@ export function FollowButton({
 
       if (response.error) {
         callToast({ variant: 'error', description: response.error });
-        setStatus('error');
+        setStatus(REQUEST_STATUS.error as RequestStatus);
         return;
       }
 
       setIsFollowing((prev) => !prev);
-      setStatus('success');
+      setStatus(REQUEST_STATUS.success as RequestStatus);
 
       callToast({ variant: 'success', description: response.data });
       actionAfterFollow?.();
     } catch (e: any) {
       sentryErrorReport(e?.message, `FOLLOW_BUTTON - ${endpoint}`);
-      setStatus('error');
+      setStatus(REQUEST_STATUS.error as RequestStatus);
     }
   };
 

--- a/src/components/ui/FollowButton.tsx
+++ b/src/components/ui/FollowButton.tsx
@@ -54,7 +54,7 @@ export function FollowButton({
   const isLoading = status === REQUEST_STATUS.loading;
 
   const handleClick = async () => {
-    setStatus(REQUEST_STATUS.loading as RequestStatus);
+    setStatus(REQUEST_STATUS.loading);
     const endpoint = isFollowing ? unfollowEndpoint : followEndpoint;
 
     try {
@@ -62,18 +62,18 @@ export function FollowButton({
 
       if (response.error) {
         callToast({ variant: 'error', description: response.error });
-        setStatus(REQUEST_STATUS.error as RequestStatus);
+        setStatus(REQUEST_STATUS.error);
         return;
       }
 
       setIsFollowing((prev) => !prev);
-      setStatus(REQUEST_STATUS.success as RequestStatus);
+      setStatus(REQUEST_STATUS.success);
 
       callToast({ variant: 'success', description: response.data });
       actionAfterFollow?.();
     } catch (e: any) {
       sentryErrorReport(e?.message, `FOLLOW_BUTTON - ${endpoint}`);
-      setStatus(REQUEST_STATUS.error as RequestStatus);
+      setStatus(REQUEST_STATUS.error);
     }
   };
 

--- a/src/components/ui/ImageUploadButton.tsx
+++ b/src/components/ui/ImageUploadButton.tsx
@@ -1,9 +1,18 @@
-import { View, TouchableOpacity, Image, Alert, ScrollView } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Image,
+  Alert,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
 import { CustomText } from '@/components/ui/CustomText';
 import * as ImagePicker from 'expo-image-picker';
 import { useTranslation } from '@/hooks/i18n/useTranslation';
 import { FontAwesome } from '@expo/vector-icons';
 import { ARTICLE_IMAGES_MAX } from '@/constants';
+import { compressImage } from '@/utils/compress-image';
+import { useState } from 'react';
 
 interface ImageUploadButtonProps {
   // Para modo simple (una sola imagen)
@@ -37,6 +46,7 @@ export function ImageUploadButton({
   disabled = false,
 }: ImageUploadButtonProps) {
   const { t } = useTranslation();
+  const [isCompressing, setIsCompressing] = useState(false);
 
   // Determinar si ya alcanzó el límite de imágenes
   const hasReachedLimit = multiple
@@ -66,40 +76,48 @@ export function ImageUploadButton({
     });
 
     if (!result.canceled && result.assets && result.assets.length > 0) {
-      if (multiple) {
-        // Modo múltiple: agregar todas las imágenes seleccionadas
-        const newImageUris = result.assets.map((asset) => asset.uri);
-        const allImages = [...selectedImages, ...newImageUris].slice(
-          0,
-          maxImages
-        );
-        onImagesSelected?.(allImages);
+      setIsCompressing(true);
 
-        // Verificar si alguna imagen es muy grande
-        const largeImages = result.assets.filter(
-          (asset) => asset.fileSize && asset.fileSize > 1024 * 1024
-        );
-        if (largeImages.length > 0) {
-          Alert.alert(
-            t('screens.editProfile.imageTooLarge'),
-            t('screens.editProfile.imageTooLargeMessage'),
-            [{ text: t('commonActions.ok') }]
-          );
-        }
-      } else {
-        // Modo simple: una sola imagen
-        const imageUri = result.assets[0].uri;
-        onImageSelected?.(imageUri);
+      try {
+        if (multiple) {
+          // Modo múltiple: comprimir todas las imágenes seleccionadas
+          const compressionPromises = result.assets.map(async (asset) => {
+            const compressedUri = await compressImage(asset.uri);
+            return compressedUri || asset.uri; // Fallback a URI original si falla
+          });
 
-        // Verificar tamaño del archivo
-        const fileSize = result.assets[0].fileSize;
-        if (fileSize && fileSize > 1024 * 1024) {
-          Alert.alert(
-            t('screens.editProfile.imageTooLarge'),
-            t('screens.editProfile.imageTooLargeMessage'),
-            [{ text: t('commonActions.ok') }]
+          const compressedUris = await Promise.all(compressionPromises);
+          const allImages = [...selectedImages, ...compressedUris].slice(
+            0,
+            maxImages
           );
+          onImagesSelected?.(allImages);
+        } else {
+          // Modo simple: comprimir una sola imagen
+          const originalUri = result.assets[0].uri;
+          const compressedUri = await compressImage(originalUri);
+
+          if (!compressedUri) {
+            // Si falla la compresión, mostrar error y no continuar
+            Alert.alert(
+              t('commonErrors.generic'),
+              t('screens.editProfile.compressionError'),
+              [{ text: t('commonActions.ok') }]
+            );
+            return;
+          }
+
+          onImageSelected?.(compressedUri);
         }
+      } catch (error) {
+        console.error('ERROR_COMPRESS_IMAGE_PICKER', error);
+        Alert.alert(
+          t('commonErrors.generic'),
+          t('screens.editProfile.compressionError'),
+          [{ text: t('commonActions.ok') }]
+        );
+      } finally {
+        setIsCompressing(false);
       }
     }
   };
@@ -196,35 +214,53 @@ export function ImageUploadButton({
         {!hasReachedLimit && (
           <TouchableOpacity
             onPress={pickImage}
-            disabled={disabled}
+            disabled={disabled || isCompressing}
             className='items-center py-2'
             activeOpacity={0.7}
           >
-            <FontAwesome
-              name='cloud-upload'
-              size={32}
-              color='#9ca3af'
-              style={{ marginBottom: 6 }}
-            />
-            <CustomText
-              type='body'
-              className='text-gray-600 mb-1 text-center'
-            >
-              {multiple
-                ? selectedImages.length > 0
-                  ? t('screens.editProfile.addMoreImages')
-                  : t('screens.editProfile.uploadImageButton')
-                : selectedImage
-                  ? t('screens.editProfile.changeImageText')
-                  : t('screens.editProfile.uploadImageButton')}
-            </CustomText>
-            {multiple && (
-              <CustomText
-                type='bodysmall'
-                className='text-gray-400 text-xs'
-              >
-                {selectedImages.length} / {maxImages}
-              </CustomText>
+            {isCompressing ? (
+              <>
+                <ActivityIndicator
+                  size='large'
+                  color='#e63946'
+                  style={{ marginBottom: 6 }}
+                />
+                <CustomText
+                  type='body'
+                  className='text-gray-600 mb-1 text-center'
+                >
+                  {t('screens.editProfile.compressingImages')}
+                </CustomText>
+              </>
+            ) : (
+              <>
+                <FontAwesome
+                  name='cloud-upload'
+                  size={32}
+                  color='#9ca3af'
+                  style={{ marginBottom: 6 }}
+                />
+                <CustomText
+                  type='body'
+                  className='text-gray-600 mb-1 text-center'
+                >
+                  {multiple
+                    ? selectedImages.length > 0
+                      ? t('screens.editProfile.addMoreImages')
+                      : t('screens.editProfile.uploadImageButton')
+                    : selectedImage
+                      ? t('screens.editProfile.changeImageText')
+                      : t('screens.editProfile.uploadImageButton')}
+                </CustomText>
+                {multiple && (
+                  <CustomText
+                    type='bodysmall'
+                    className='text-gray-400 text-xs'
+                  >
+                    {selectedImages.length} / {maxImages}
+                  </CustomText>
+                )}
+              </>
             )}
           </TouchableOpacity>
         )}

--- a/src/components/ui/ImageUploadButton.tsx
+++ b/src/components/ui/ImageUploadButton.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   View,
   TouchableOpacity,
@@ -64,8 +63,8 @@ export function ImageUploadButton({
       callToast({
         variant: 'error',
         description: {
-          en: t('screens.editProfile.permissionDenied'),
-          es: t('screens.editProfile.permissionDenied'),
+          en: 'Permission Required',
+          es: 'Permiso Requerido',
         },
       });
       return;

--- a/src/components/ui/ImageUploadButton.tsx
+++ b/src/components/ui/ImageUploadButton.tsx
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   View,
   TouchableOpacity,
   Image,
-  Alert,
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
@@ -13,6 +13,7 @@ import { FontAwesome } from '@expo/vector-icons';
 import { ARTICLE_IMAGES_MAX } from '@/constants';
 import { compressImage } from '@/utils/compress-image';
 import { useState } from 'react';
+import { useToast } from '@/hooks/useToast';
 
 interface ImageUploadButtonProps {
   // Para modo simple (una sola imagen)
@@ -45,7 +46,8 @@ export function ImageUploadButton({
   maxImages = ARTICLE_IMAGES_MAX,
   disabled = false,
 }: ImageUploadButtonProps) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
+  const { callToast } = useToast(locale);
   const [isCompressing, setIsCompressing] = useState(false);
 
   // Determinar si ya alcanzó el límite de imágenes
@@ -59,11 +61,13 @@ export function ImageUploadButton({
       await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (!permissionResult.granted) {
-      Alert.alert(
-        t('screens.editProfile.permissionRequired'),
-        t('screens.editProfile.permissionMessage'),
-        [{ text: t('commonActions.ok') }]
-      );
+      callToast({
+        variant: 'error',
+        description: {
+          en: t('screens.editProfile.permissionDenied'),
+          es: t('screens.editProfile.permissionDenied'),
+        },
+      });
       return;
     }
 
@@ -99,23 +103,26 @@ export function ImageUploadButton({
 
           if (!compressedUri) {
             // Si falla la compresión, mostrar error y no continuar
-            Alert.alert(
-              t('commonErrors.generic'),
-              t('screens.editProfile.compressionError'),
-              [{ text: t('commonActions.ok') }]
-            );
+            callToast({
+              variant: 'error',
+              description: {
+                en: t('screens.editProfile.compressionFailed'),
+                es: t('screens.editProfile.compressionFailed'),
+              },
+            });
             return;
           }
 
           onImageSelected?.(compressedUri);
         }
       } catch (error) {
-        console.error('ERROR_COMPRESS_IMAGE_PICKER', error);
-        Alert.alert(
-          t('commonErrors.generic'),
-          t('screens.editProfile.compressionError'),
-          [{ text: t('commonActions.ok') }]
-        );
+        callToast({
+          variant: 'error',
+          description: {
+            en: 'Failed to compress image. Please try another one.',
+            es: 'Error al comprimir la imagen. Por favor intenta con otra.',
+          },
+        });
       } finally {
         setIsCompressing(false);
       }

--- a/src/components/ui/ImageUploadButton.tsx
+++ b/src/components/ui/ImageUploadButton.tsx
@@ -62,10 +62,7 @@ export function ImageUploadButton({
     if (!permissionResult.granted) {
       callToast({
         variant: 'error',
-        description: {
-          en: 'Permission Required',
-          es: 'Permiso Requerido',
-        },
+        description: 'screens.editProfile.permissionRequired',
       });
       return;
     }
@@ -104,23 +101,17 @@ export function ImageUploadButton({
             // Si falla la compresión, mostrar error y no continuar
             callToast({
               variant: 'error',
-              description: {
-                en: t('screens.editProfile.compressionFailed'),
-                es: t('screens.editProfile.compressionFailed'),
-              },
+              description: 'screens.editProfile.compressionError',
             });
             return;
           }
 
           onImageSelected?.(compressedUri);
         }
-      } catch (error) {
+      } catch {
         callToast({
           variant: 'error',
-          description: {
-            en: 'Failed to compress image. Please try another one.',
-            es: 'Error al comprimir la imagen. Por favor intenta con otra.',
-          },
+          description: 'screens.editProfile.compressionError',
         });
       } finally {
         setIsCompressing(false);

--- a/src/components/verify-phone/VerifyPhoneWizard.tsx
+++ b/src/components/verify-phone/VerifyPhoneWizard.tsx
@@ -59,10 +59,7 @@ export function VerifyPhoneWizard({
     if (!isValidPhone || !phoneNumber) {
       callToast({
         variant: 'error',
-        description: {
-          en: 'Please enter a valid phone number',
-          es: 'Por favor ingrese un número de teléfono válido',
-        },
+        description: 'screens.verifyPhone.invalidPhoneNumber',
       });
       return;
     }
@@ -80,10 +77,7 @@ export function VerifyPhoneWizard({
     ) {
       callToast({
         variant: 'error',
-        description: {
-          en: 'This number is already verified. Please enter a different one.',
-          es: 'Este número ya está verificado. Ingresa uno diferente.',
-        },
+        description: 'screens.verifyPhone.alreadyVerified',
       });
       return;
     }
@@ -98,10 +92,7 @@ export function VerifyPhoneWizard({
       setOtpCode(''); // Clear OTP input
       callToast({
         variant: 'success',
-        description: {
-          en: 'Verification code sent successfully',
-          es: 'Código de verificación enviado exitosamente',
-        },
+        description: 'screens.verifyPhone.codeSentSuccess',
       });
     }
   };
@@ -125,10 +116,7 @@ export function VerifyPhoneWizard({
     if (!otpCode || otpCode.length < 6) {
       callToast({
         variant: 'error',
-        description: {
-          en: 'Please enter the 6-digit code',
-          es: 'Por favor ingrese el código de 6 dígitos',
-        },
+        description: 'screens.verifyPhone.invalidCode',
       });
       return;
     }
@@ -146,10 +134,7 @@ export function VerifyPhoneWizard({
       setStep(3);
       callToast({
         variant: 'success',
-        description: {
-          en: 'Phone verified successfully!',
-          es: '¡Teléfono verificado exitosamente!',
-        },
+        description: 'screens.verifyPhone.verifiedSuccess',
       });
     } else {
       // Clear OTP input if verification failed

--- a/src/components/verify-phone/VerifyPhoneWizard.tsx
+++ b/src/components/verify-phone/VerifyPhoneWizard.tsx
@@ -25,7 +25,7 @@ export function VerifyPhoneWizard({
 }: VerifyPhoneWizardProps) {
   const { t, locale } = useTranslation();
   const router = useRouter();
-  const { toast } = useToast(locale);
+  const { callToast } = useToast(locale);
   const { sendOtp, verifyOtp, errorMessage, canResend, remainingSeconds } =
     useVerifyPhone();
 
@@ -43,9 +43,9 @@ export function VerifyPhoneWizard({
   // Show toast when errorMessage changes from hook
   useEffect(() => {
     if (errorMessage) {
-      toast.error({ description: errorMessage });
+      callToast({ variant: 'error', description: errorMessage });
     }
-  }, [errorMessage, toast]);
+  }, [errorMessage, callToast]);
 
   // Update phone validation when phoneNumber or selectedCountry changes
   useEffect(() => {
@@ -57,10 +57,11 @@ export function VerifyPhoneWizard({
   // Step 1: Send OTP
   const handleSendCode = async () => {
     if (!isValidPhone || !phoneNumber) {
-      toast.error({
+      callToast({
+        variant: 'error',
         description: {
-          en: 'Please enter a valid phone number',
-          es: 'Por favor ingrese un número de teléfono válido',
+          en: t('screens.verifyPhone.invalidPhoneNumber'),
+          es: t('screens.verifyPhone.invalidPhoneNumber'),
         },
       });
       return;
@@ -77,10 +78,11 @@ export function VerifyPhoneWizard({
       isPhoneVerified &&
       fullPhone.replace(/\s/g, '') === verifiedPhoneNumber.replace(/\s/g, '')
     ) {
-      toast.error({
+      callToast({
+        variant: 'error',
         description: {
-          en: 'This number is already verified. Please enter a different one.',
-          es: 'Este número ya está verificado. Ingresa uno diferente.',
+          en: t('screens.verifyPhone.alreadyVerified'),
+          es: t('screens.verifyPhone.alreadyVerified'),
         },
       });
       return;
@@ -94,6 +96,13 @@ export function VerifyPhoneWizard({
     if (result.success) {
       setStep(2);
       setOtpCode(''); // Clear OTP input
+      callToast({
+        variant: 'success',
+        description: {
+          en: t('screens.verifyPhone.codeSentSuccess'),
+          es: t('screens.verifyPhone.codeSentSuccess'),
+        },
+      });
     }
   };
 
@@ -114,10 +123,11 @@ export function VerifyPhoneWizard({
   // Step 2: Verify OTP
   const handleVerifyCode = async () => {
     if (!otpCode || otpCode.length < 6) {
-      toast.error({
+      callToast({
+        variant: 'error',
         description: {
-          en: 'Please enter the 6-digit code',
-          es: 'Por favor ingrese el código de 6 dígitos',
+          en: t('screens.verifyPhone.invalidCode'),
+          es: t('screens.verifyPhone.invalidCode'),
         },
       });
       return;
@@ -134,6 +144,13 @@ export function VerifyPhoneWizard({
 
     if (result.success) {
       setStep(3);
+      callToast({
+        variant: 'success',
+        description: {
+          en: t('screens.verifyPhone.verifiedSuccess'),
+          es: t('screens.verifyPhone.verifiedSuccess'),
+        },
+      });
     } else {
       // Clear OTP input if verification failed
       setOtpCode('');

--- a/src/components/verify-phone/VerifyPhoneWizard.tsx
+++ b/src/components/verify-phone/VerifyPhoneWizard.tsx
@@ -60,8 +60,8 @@ export function VerifyPhoneWizard({
       callToast({
         variant: 'error',
         description: {
-          en: t('screens.verifyPhone.invalidPhoneNumber'),
-          es: t('screens.verifyPhone.invalidPhoneNumber'),
+          en: 'Please enter a valid phone number',
+          es: 'Por favor ingrese un número de teléfono válido',
         },
       });
       return;
@@ -81,8 +81,8 @@ export function VerifyPhoneWizard({
       callToast({
         variant: 'error',
         description: {
-          en: t('screens.verifyPhone.alreadyVerified'),
-          es: t('screens.verifyPhone.alreadyVerified'),
+          en: 'This number is already verified. Please enter a different one.',
+          es: 'Este número ya está verificado. Ingresa uno diferente.',
         },
       });
       return;
@@ -99,8 +99,8 @@ export function VerifyPhoneWizard({
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.verifyPhone.codeSentSuccess'),
-          es: t('screens.verifyPhone.codeSentSuccess'),
+          en: 'Verification code sent successfully',
+          es: 'Código de verificación enviado exitosamente',
         },
       });
     }
@@ -126,8 +126,8 @@ export function VerifyPhoneWizard({
       callToast({
         variant: 'error',
         description: {
-          en: t('screens.verifyPhone.invalidCode'),
-          es: t('screens.verifyPhone.invalidCode'),
+          en: 'Please enter the 6-digit code',
+          es: 'Por favor ingrese el código de 6 dígitos',
         },
       });
       return;
@@ -147,8 +147,8 @@ export function VerifyPhoneWizard({
       callToast({
         variant: 'success',
         description: {
-          en: t('screens.verifyPhone.verifiedSuccess'),
-          es: t('screens.verifyPhone.verifiedSuccess'),
+          en: 'Phone verified successfully!',
+          es: '¡Teléfono verificado exitosamente!',
         },
       });
     } else {

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -52,9 +52,9 @@ export const ARTICLE_PRICE_FILTER_LIST = [
   { value: '>2000', label: '> 2000€' },
 ];
 
-export const REQUEST_STATUS: Record<RequestStatus, string> = {
+export const REQUEST_STATUS = {
   idle: 'idle',
   loading: 'loading',
   success: 'success',
   error: 'error',
-};
+} as const;

--- a/src/hooks/pages/payment/useGetPaymentHistory.ts
+++ b/src/hooks/pages/payment/useGetPaymentHistory.ts
@@ -29,7 +29,6 @@ export const useGetPaymentHistory = (): ActionResponse<UserPayment[]> & {
       });
 
       if (response.error) {
-        console.error('ERROR_LOAD_PAYMENT_HISTORY', response.error);
         setStatus('error');
         setErrorMessage(response.error);
         return;

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -37,12 +37,13 @@ export function useToast(lang: Lang) {
     // Handle description: can be LangMap, translation key string, or null
     let text2: string | undefined;
     if (description) {
-      if (typeof description === 'string') {
-        // Translation key - translate it
-        text2 = t(description as any);
-      } else {
-        // LangMap - extract the text for current language
+      if (typeof description === 'object' && description !== null) {
+        // LangMap object - prioritize this over string
+        // Extract the text for current language
         text2 = description[lang];
+      } else if (typeof description === 'string') {
+        // Translation key string - translate it
+        text2 = t(description as any);
       }
     }
 

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -2,6 +2,7 @@ import Toast from 'react-native-toast-message';
 import * as Haptics from 'expo-haptics';
 import type { Lang, LangMap } from '@/types/types';
 import { TOAST_TEXTS, ToastVariant } from '@/providers/ToastProvider';
+import { t } from '@/i18n';
 
 type ToastPosition = 'top' | 'bottom';
 
@@ -16,7 +17,7 @@ export function useToast(lang: Lang) {
     onAction,
   }: {
     variant?: ToastVariant;
-    description?: LangMap | null;
+    description?: LangMap | string | null;
     position?: ToastPosition;
     durationMs?: number;
     haptics?: boolean;
@@ -33,11 +34,23 @@ export function useToast(lang: Lang) {
       Haptics.notificationAsync(type).catch(() => {});
     }
 
+    // Handle description: can be LangMap, translation key string, or null
+    let text2: string | undefined;
+    if (description) {
+      if (typeof description === 'string') {
+        // Translation key - translate it
+        text2 = t(description as any);
+      } else {
+        // LangMap - extract the text for current language
+        text2 = description[lang];
+      }
+    }
+
     Toast.show({
       type: variant,
       position,
       text1: TOAST_TEXTS[lang][variant],
-      text2: description ? description[lang] : undefined,
+      text2,
       visibilityTime: durationMs,
       // props: { actionLabel, onAction },
     });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -361,6 +361,11 @@
     }
   },
   "commonErrors": {
+    "networkError": "Internet connection error",
+    "applicationError": "An error occurred while loading the application",
+    "defaultMessage": "Please check your internet connection and restart Expo. If the problem persists, contact support.",
+    "tryAgain": "Try again",
+    "generic": "Something went wrong",
     "loadFailedTitle": "Error loading",
     "loadFailedMessage": "Could not load information. Please try again.",
     "retryButton": "Retry"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -220,6 +220,8 @@
       "permissionMessage": "We need access to your gallery to select an image.",
       "imageTooLarge": "Image too large",
       "imageTooLargeMessage": "The selected image is larger than 1MB. It will be compressed automatically.",
+      "compressionError": "Failed to compress image. Please try another one.",
+      "compressingImages": "Compressing images...",
       "update": "Update",
       "back": "Back"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -361,11 +361,6 @@
     }
   },
   "commonErrors": {
-    "networkError": "Internet connection error",
-    "applicationError": "An error occurred while loading the application",
-    "defaultMessage": "Please check your internet connection and restart Expo. If the problem persists, contact support.",
-    "tryAgain": "Try again",
-    "generic": "Something went wrong",
     "loadFailedTitle": "Error loading",
     "loadFailedMessage": "Could not load information. Please try again.",
     "retryButton": "Retry"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -222,6 +222,11 @@
       "imageTooLargeMessage": "The selected image is larger than 1MB. It will be compressed automatically.",
       "compressionError": "Failed to compress image. Please try another one.",
       "compressingImages": "Compressing images...",
+      "updateSuccess": "Profile updated successfully",
+      "updateError": "Failed to update profile",
+      "loadError": "Failed to load user data",
+      "permissionDenied": "Permission required to access gallery",
+      "compressionFailed": "Failed to compress image. Please try another one.",
       "update": "Update",
       "back": "Back"
     },
@@ -250,7 +255,12 @@
       "successMessage": "Phone verified!",
       "goToProfileButton": "Go to profile",
       "invalidPhoneError": "Invalid phone number format",
-      "invalidCodeError": "Invalid verification code"
+      "invalidCodeError": "Invalid verification code",
+      "invalidPhoneNumber": "Please enter a valid phone number",
+      "alreadyVerified": "This number is already verified. Please enter a different one.",
+      "codeSentSuccess": "Verification code sent successfully",
+      "invalidCode": "Please enter the 6-digit code",
+      "verifiedSuccess": "Phone verified successfully!"
     },
     "addresses": {
       "title": "My Addresses",
@@ -301,7 +311,11 @@
       "billingAddress": "Billing address",
       "billingAddressPlaceholder": "Complete address",
       "vatNumber": "Tax ID / VAT number",
-      "vatNumberPlaceholder": "RFC, NIT, RUT, etc.",
+      "vatNumberPlaceholder": "E.g.: B12345678",
+      "createSuccess": "Billing information created successfully",
+      "updateSuccess": "Billing information updated successfully",
+      "deleteSuccess": "Billing information deleted successfully",
+      "deleteInfo": "Deleting billing information...",
       "success": "Information saved successfully",
       "error": "Error saving information"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -365,7 +365,10 @@
     "applicationError": "An error occurred while loading the application",
     "defaultMessage": "Please check your internet connection and restart Expo. If the problem persists, contact support.",
     "tryAgain": "Try again",
-    "generic": "Something went wrong"
+    "generic": "Something went wrong",
+    "loadFailedTitle": "Error loading",
+    "loadFailedMessage": "Could not load information. Please try again.",
+    "retryButton": "Retry"
   },
   "errorLoading": {
     "title": "Loading Error",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -363,7 +363,7 @@
   "commonErrors": {
     "networkError": "Internet connection error",
     "applicationError": "An error occurred while loading the application",
-    "defaultMessage": "Please check your internet connection and restart Expo. If the problem persists, contact support.",
+    "defaultMessage": "If the problem persists, contact support.",
     "tryAgain": "Try again",
     "generic": "Something went wrong",
     "loadFailedTitle": "Error loading",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -233,6 +233,11 @@
       "imageTooLargeMessage": "La imagen seleccionada es mayor a 1MB. Se comprimirá automáticamente.",
       "compressionError": "Error al comprimir la imagen. Por favor intenta con otra.",
       "compressingImages": "Comprimiendo imágenes...",
+      "updateSuccess": "Perfil actualizado exitosamente",
+      "updateError": "Error al actualizar el perfil",
+      "loadError": "Error al cargar datos del usuario",
+      "permissionDenied": "Se requiere permiso para acceder a la galería",
+      "compressionFailed": "Error al comprimir la imagen. Por favor intenta con otra.",
       "update": "Actualizar",
       "back": "Volver"
     },
@@ -261,7 +266,12 @@
       "successMessage": "¡Teléfono verificado!",
       "goToProfileButton": "Ir a perfil",
       "invalidPhoneError": "Formato de número de teléfono inválido",
-      "invalidCodeError": "Código de verificación inválido"
+      "invalidCodeError": "Código de verificación inválido",
+      "invalidPhoneNumber": "Por favor ingrese un número de teléfono válido",
+      "alreadyVerified": "Este número ya está verificado. Ingresa uno diferente.",
+      "codeSentSuccess": "Código de verificación enviado exitosamente",
+      "invalidCode": "Por favor ingrese el código de 6 dígitos",
+      "verifiedSuccess": "¡Teléfono verificado exitosamente!"
     },
     "addresses": {
       "title": "Mis Direcciones",
@@ -289,7 +299,9 @@
         "postalCode": "Código postal",
         "setPrimary": "Establecer como dirección principal",
         "submit": "Guardar dirección",
-        "cancel": "Cancelar"
+        "cancel": "Cancelar",
+        "createSuccess": "Dirección creada exitosamente",
+        "createError": "Error al crear la dirección"
       },
       "success": "Dirección guardada correctamente",
       "error": "Error al guardar la dirección"
@@ -312,7 +324,11 @@
       "billingAddress": "Dirección de facturación",
       "billingAddressPlaceholder": "Dirección completa",
       "vatNumber": "Número de identificación fiscal / NIT",
-      "vatNumberPlaceholder": "RFC, NIT, RUT, etc.",
+      "vatNumberPlaceholder": "Ej: B12345678",
+      "createSuccess": "Información de facturación creada exitosamente",
+      "updateSuccess": "Información de facturación actualizada exitosamente",
+      "deleteSuccess": "Información de facturación eliminada exitosamente",
+      "deleteInfo": "Eliminando información de facturación...",
       "success": "Información guardada correctamente",
       "error": "Error al guardar la información"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -231,6 +231,8 @@
       "permissionMessage": "Necesitamos acceso a tu galería para seleccionar una imagen.",
       "imageTooLarge": "Imagen muy grande",
       "imageTooLargeMessage": "La imagen seleccionada es mayor a 1MB. Se comprimirá automáticamente.",
+      "compressionError": "Error al comprimir la imagen. Por favor intenta con otra.",
+      "compressingImages": "Comprimiendo imágenes...",
       "update": "Actualizar",
       "back": "Volver"
     },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -378,7 +378,10 @@
     "applicationError": "Ocurrió un error al cargar la aplicación",
     "defaultMessage": "Por favor, verifica tu conexión a internet y reinicia Expo. Si el problema persiste, contacta soporte.",
     "tryAgain": "Intentar de nuevo",
-    "generic": "Algo salió mal"
+    "generic": "Algo salió mal",
+    "loadFailedTitle": "Error al cargar",
+    "loadFailedMessage": "No se pudo cargar la información. Por favor, intenta de nuevo.",
+    "retryButton": "Reintentar"
   },
   "errorLoading": {
     "title": "Error de Carga",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -374,6 +374,11 @@
     }
   },
   "commonErrors": {
+    "networkError": "Error de conexión a internet",
+    "applicationError": "Ocurrió un error al cargar la aplicación",
+    "defaultMessage": "Por favor, verifica tu conexión a internet y reinicia Expo. Si el problema persiste, contacta soporte.",
+    "tryAgain": "Intentar de nuevo",
+    "generic": "Algo salió mal",
     "loadFailedTitle": "Error al cargar",
     "loadFailedMessage": "No se pudo cargar la información. Por favor, intenta de nuevo.",
     "retryButton": "Reintentar"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -374,11 +374,6 @@
     }
   },
   "commonErrors": {
-    "networkError": "Error de conexión a internet",
-    "applicationError": "Ocurrió un error al cargar la aplicación",
-    "defaultMessage": "Por favor, verifica tu conexión a internet y reinicia Expo. Si el problema persiste, contacta soporte.",
-    "tryAgain": "Intentar de nuevo",
-    "generic": "Algo salió mal",
     "loadFailedTitle": "Error al cargar",
     "loadFailedMessage": "No se pudo cargar la información. Por favor, intenta de nuevo.",
     "retryButton": "Reintentar"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -376,7 +376,7 @@
   "commonErrors": {
     "networkError": "Error de conexión a internet",
     "applicationError": "Ocurrió un error al cargar la aplicación",
-    "defaultMessage": "Por favor, verifica tu conexión a internet y reinicia Expo. Si el problema persiste, contacta soporte.",
+    "defaultMessage": "Si el problema persiste, contacta soporte.",
     "tryAgain": "Intentar de nuevo",
     "generic": "Algo salió mal",
     "loadFailedTitle": "Error al cargar",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -299,9 +299,7 @@
         "postalCode": "Código postal",
         "setPrimary": "Establecer como dirección principal",
         "submit": "Guardar dirección",
-        "cancel": "Cancelar",
-        "createSuccess": "Dirección creada exitosamente",
-        "createError": "Error al crear la dirección"
+        "cancel": "Cancelar"
       },
       "success": "Dirección guardada correctamente",
       "error": "Error al guardar la dirección"

--- a/src/utils/compress-image.ts
+++ b/src/utils/compress-image.ts
@@ -1,0 +1,28 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+
+/**
+ * Compresses an image to optimize file size and dimensions
+ * - Resizes to max 1024px width (maintains aspect ratio)
+ * - Compresses to 70% quality
+ * - Converts to WebP format for optimal size
+ *
+ * @param uri - The local URI of the image to compress
+ * @returns The URI of the compressed image, or null if compression failed
+ */
+export async function compressImage(uri: string): Promise<string | null> {
+  try {
+    const manipResult = await ImageManipulator.manipulateAsync(
+      uri,
+      [{ resize: { width: 1024 } }], // Resize maintaining aspect ratio
+      {
+        compress: 0.7, // 70% quality
+        format: ImageManipulator.SaveFormat.WEBP,
+      }
+    );
+
+    return manipResult.uri;
+  } catch (error) {
+    console.error('ERROR_COMPRESS_IMAGE', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 📋 Resumen

Migración completa de checks de status usando string literals a la constante centralizada `REQUEST_STATUS` en toda la aplicación cliente (frontend).

## 🎯 Objetivo

Mejorar la mantenibilidad del código eliminando valores literales de string dispersos y reemplazarlos con una constante centralizada que previene errores tipográficos y facilita refactoring futuro.

## 🔧 Cambios Realizados

### Screens actualizadas:
- **`app/(tabs)/account/edit-profile.tsx`**
  - Migrado `updateStatus` checks a `REQUEST_STATUS`

- **`app/(tabs)/account/billing-info.tsx`**
  - Migrado `status` y `deleteStatus` checks a `REQUEST_STATUS`
  - Agregado import de `REQUEST_STATUS`

- **`app/(tabs)/account/verify-phone.tsx`**
  - Migrado todos los checks de `status` a `REQUEST_STATUS`
  - Mantenido comportamiento de redirect a account

- **`app/(tabs)/auctions/calendar.tsx`**
  - Migrado `status` checks a `REQUEST_STATUS`

### Componentes actualizados:
- **`src/components/billing-info/BillingFormModal.tsx`**
  - Migrado `currentStatus` checks a `REQUEST_STATUS`

- **`src/components/addresses/AddressFormModal.tsx`**
  - Migrado `status` checks a `REQUEST_STATUS`

- **`src/components/ui/FollowButton.tsx`**
  - Migrado `status` checks y `setStatus` calls a `REQUEST_STATUS`
  - Agregado type assertions necesarios para compatibilidad con `RequestStatus` type

## 🔍 Patrón de Migración

### Antes:
```typescript
if (status === 'loading') { /* ... */ }
if (status === 'error') { /* ... */ }
if (status === 'success') { /* ... */ }